### PR TITLE
Add Gmail ingestion skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+OPENAI_API_KEY=your_openai_api_key
+EXA_API_KEY=your_exa_api_key
+BROWSERBASE_API_KEY=your_key
+GMAIL_CLIENT_ID=your_client_id
+GMAIL_CLIENT_SECRET=your_client_secret
+GMAIL_REDIRECT_URI=http://localhost:3000/gmail/callback

--- a/electron/bootstrap/registerIpcHandlers.ts
+++ b/electron/bootstrap/registerIpcHandlers.ts
@@ -45,6 +45,7 @@ import { registerClassicBrowserSetBackgroundColorHandler } from '../ipc/classicB
 import { registerSyncWindowStackOrderHandler } from '../ipc/syncWindowStackOrder';
 import { registerAudioHandlers } from '../ipc/audioHandlers';
 import { registerWOMHandlers } from '../ipc/womHandlers';
+import { registerGmailHandlers } from '../ipc/gmailHandlers';
 
 export function registerAllIpcHandlers(
   serviceRegistry: ServiceRegistry,
@@ -182,6 +183,11 @@ export function registerAllIpcHandlers(
   
   // Register Open External URL Handler
   registerOpenExternalUrlHandler();
+
+  if (serviceRegistry.gmailAuth && ingestionQueueService) {
+    registerGmailHandlers(ipcMain, serviceRegistry);
+    logger.info('[IPC] Gmail IPC handlers registered.');
+  }
   
   // Register PDF Ingestion Handlers
   if (pdfIngestionService && mainWindow) {

--- a/electron/ipc/gmailHandlers.ts
+++ b/electron/ipc/gmailHandlers.ts
@@ -1,0 +1,25 @@
+import { IpcMain } from 'electron';
+import {
+  GMAIL_AUTH_URL,
+  GMAIL_AUTH_CALLBACK,
+  GMAIL_SYNC
+} from '../../shared/ipcChannels';
+import type { ServiceRegistry } from '../bootstrap/serviceBootstrap';
+
+export function registerGmailHandlers(ipcMain: IpcMain, services: ServiceRegistry) {
+  ipcMain.handle(GMAIL_AUTH_URL, async () => {
+    return services.gmailAuth?.getAuthUrl();
+  });
+
+  ipcMain.handle(GMAIL_AUTH_CALLBACK, async (_event, code: string) => {
+    const userId = 'default_user';
+    return services.gmailAuth?.handleAuthCallback(code, userId);
+  });
+
+  ipcMain.handle(GMAIL_SYNC, async () => {
+    const userId = 'default_user';
+    return services.ingestionQueue?.addJob('email', 'gmail', {
+      jobSpecificData: { userId }
+    });
+  });
+}

--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
     "uuid": "^11.1.0",
     "vectordb": "^0.4.0",
     "zod": "^3.25.32",
-    "zustand": "^5.0.4"
+    "zustand": "^5.0.4",
+    "googleapis": "^119.0.0"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^4.0.0",
@@ -115,6 +116,7 @@
     "@types/pdf-parse": "^1.1.4",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/google-auth-library": "^9",
     "@vitejs/plugin-react": "^4.6.0",
     "@vitest/browser": "^3.1.3",
     "@vitest/coverage-v8": "^3.1.3",

--- a/services/GmailAuthService.ts
+++ b/services/GmailAuthService.ts
@@ -1,0 +1,63 @@
+import { BaseService } from './base/BaseService';
+import { GmailAuthError } from './base/ServiceError';
+import type Database from 'better-sqlite3';
+import { OAuth2Client } from 'google-auth-library';
+import type { ProfileService } from './ProfileService';
+
+interface GmailAuthServiceDeps {
+  db: Database.Database;
+  profileService: ProfileService;
+}
+
+export class GmailAuthService extends BaseService<GmailAuthServiceDeps> {
+  private oauth2Client!: OAuth2Client;
+
+  constructor(deps: GmailAuthServiceDeps) {
+    super('GmailAuthService', deps);
+  }
+
+  async initialize(): Promise<void> {
+    await super.initialize();
+    const clientId = process.env.GMAIL_CLIENT_ID;
+    const clientSecret = process.env.GMAIL_CLIENT_SECRET;
+    const redirectUri = process.env.GMAIL_REDIRECT_URI;
+
+    if (!clientId || !clientSecret || !redirectUri) {
+      throw new GmailAuthError('Missing Gmail OAuth environment variables');
+    }
+
+    this.oauth2Client = new OAuth2Client({
+      clientId,
+      clientSecret,
+      redirectUri
+    });
+  }
+
+  getAuthUrl(): string {
+    const scopes = ['https://www.googleapis.com/auth/gmail.readonly'];
+    return this.oauth2Client.generateAuthUrl({ access_type: 'offline', scope: scopes });
+  }
+
+  async handleAuthCallback(code: string, userId: string): Promise<void> {
+    try {
+      const { tokens } = await this.oauth2Client.getToken(code);
+      // TODO: store tokens securely per user
+      // Placeholder in-memory storage (not persisted)
+      this.tokenStore.set(userId, tokens);
+    } catch (error) {
+      this.logError('Auth callback failed', error);
+      throw new GmailAuthError('Failed to authenticate with Gmail');
+    }
+  }
+
+  private tokenStore = new Map<string, any>();
+
+  async getAuthenticatedClient(userId: string): Promise<OAuth2Client> {
+    const tokens = this.tokenStore.get(userId);
+    if (!tokens) {
+      throw new GmailAuthError('No tokens found for user');
+    }
+    this.oauth2Client.setCredentials(tokens);
+    return this.oauth2Client;
+  }
+}

--- a/services/base/ServiceError.ts
+++ b/services/base/ServiceError.ts
@@ -95,6 +95,27 @@ export class RateLimitError extends ServiceError {
   }
 }
 
+export class GmailAuthError extends ExternalServiceError {
+  constructor(message: string, details?: any) {
+    super('gmail', message, details);
+    this.name = 'GmailAuthError';
+  }
+}
+
+export class GmailRateLimitError extends ExternalServiceError {
+  constructor(message: string, details?: any) {
+    super('gmail', message, details);
+    this.name = 'GmailRateLimitError';
+  }
+}
+
+export class GmailQuotaExceededError extends ExternalServiceError {
+  constructor(message: string, details?: any) {
+    super('gmail', message, details);
+    this.name = 'GmailQuotaExceededError';
+  }
+}
+
 /**
  * Error thrown when an operation times out
  */

--- a/services/ingestion/GmailIngestionService.ts
+++ b/services/ingestion/GmailIngestionService.ts
@@ -1,0 +1,94 @@
+import { google } from 'googleapis';
+import { BaseService } from '../base/BaseService';
+import type { GmailAuthService } from '../GmailAuthService';
+import { Email } from '../../shared/types/email.types';
+import type { ObjectModel } from '../../models/ObjectModel';
+import { GmailRateLimitError, GmailQuotaExceededError } from '../base/ServiceError';
+
+interface GmailIngestionServiceDeps {
+  gmailAuthService: GmailAuthService;
+  objectModel: ObjectModel;
+}
+
+export class GmailIngestionService extends BaseService<GmailIngestionServiceDeps> {
+  constructor(deps: GmailIngestionServiceDeps) {
+    super('GmailIngestionService', deps);
+  }
+
+  async fetchRecentEmails(userId: string, maxResults = 50): Promise<Email[]> {
+    return this.execute('fetchRecentEmails', async () => {
+      const client = await this.deps.gmailAuthService.getAuthenticatedClient(userId);
+      const gmail = google.gmail({ version: 'v1', auth: client });
+      const res = await gmail.users.messages.list({ userId: 'me', maxResults });
+      const ids = res.data.messages?.map(m => m.id) || [];
+      const emails: Email[] = [];
+      for (const id of ids) {
+        const msg = await gmail.users.messages.get({ userId: 'me', id: id! });
+        emails.push(this.transformMessage(msg.data));
+      }
+      return emails;
+    });
+  }
+
+  async fetchEmailsSince(userId: string, since: Date): Promise<Email[]> {
+    const query = `after:${Math.floor(since.getTime() / 1000)}`;
+    const client = await this.deps.gmailAuthService.getAuthenticatedClient(userId);
+    const gmail = google.gmail({ version: 'v1', auth: client });
+    const res = await gmail.users.messages.list({ userId: 'me', q: query });
+    const ids = res.data.messages?.map(m => m.id) || [];
+    const emails: Email[] = [];
+    for (const id of ids) {
+      const msg = await gmail.users.messages.get({ userId: 'me', id: id! });
+      emails.push(this.transformMessage(msg.data));
+    }
+    return emails;
+  }
+
+  private transformMessage(message: any): Email {
+    const headers: Record<string, string> = {};
+    for (const h of message.payload.headers || []) {
+      headers[h.name.toLowerCase()] = h.value;
+    }
+    const getAddress = (value?: string) => {
+      if (!value) return [] as Array<{ name?: string; email: string }>;
+      return value.split(',').map(part => {
+        const match = part.match(/(?:(.*) <)?([^>]+)>?/);
+        return { name: match?.[1]?.trim(), email: match?.[2].trim() };
+      });
+    };
+    const body = this.parseEmailBody(message.payload);
+    return {
+      id: message.id,
+      threadId: message.threadId,
+      from: getAddress(headers['from'])[0],
+      to: getAddress(headers['to']),
+      cc: getAddress(headers['cc']),
+      bcc: getAddress(headers['bcc']),
+      subject: headers['subject'] || '',
+      snippet: message.snippet || '',
+      body,
+      receivedAt: new Date(parseInt(message.internalDate, 10)),
+      labels: message.labelIds || [],
+      attachments: message.payload.parts?.filter((p: any) => p.filename).map((p: any) => ({
+        filename: p.filename,
+        mimeType: p.mimeType,
+        size: Number(p.body.size) || 0
+      })),
+      headers
+    };
+  }
+
+  private parseEmailBody(payload: any): string {
+    if (!payload) return '';
+    if (payload.body?.data) {
+      return Buffer.from(payload.body.data, 'base64').toString('utf-8');
+    }
+    if (payload.parts && Array.isArray(payload.parts)) {
+      for (const part of payload.parts) {
+        const text = this.parseEmailBody(part);
+        if (text) return text;
+      }
+    }
+    return '';
+  }
+}

--- a/services/ingestion/GmailIngestionWorker.ts
+++ b/services/ingestion/GmailIngestionWorker.ts
@@ -1,0 +1,65 @@
+import { BaseIngestionWorker } from './BaseIngestionWorker';
+import { IngestionJob, IngestionJobModel } from '../../models/IngestionJobModel';
+import type { ObjectModel } from '../../models/ObjectModel';
+import type { ChunkSqlModel } from '../../models/ChunkModel';
+import type { LanceVectorModel } from '../../models/LanceVectorModel';
+import { GmailIngestionService } from './GmailIngestionService';
+import { Email } from '../../shared/types/email.types';
+import { v4 as uuidv4 } from 'uuid';
+
+export class GmailIngestionWorker extends BaseIngestionWorker {
+  protected objectModel: ObjectModel;
+  private gmailService: GmailIngestionService;
+  private chunkModel: ChunkSqlModel;
+  private vectorModel: LanceVectorModel;
+
+  constructor(
+    gmailService: GmailIngestionService,
+    objectModel: ObjectModel,
+    chunkModel: ChunkSqlModel,
+    vectorModel: LanceVectorModel,
+    ingestionJobModel: IngestionJobModel
+  ) {
+    super(ingestionJobModel, 'GmailIngestionWorker');
+    this.gmailService = gmailService;
+    this.objectModel = objectModel;
+    this.chunkModel = chunkModel;
+    this.vectorModel = vectorModel;
+  }
+
+  async execute(job: IngestionJob): Promise<void> {
+    const { userId } = job.jobSpecificData as any;
+    const emails = await this.gmailService.fetchRecentEmails(userId);
+    for (const email of emails) {
+      const objectId = await this.createEmailObject(email);
+      await this.vectorModel.upsert({
+        id: uuidv4(),
+        objectId,
+        layer: 'wom',
+        recordType: 'object',
+        mediaType: 'email',
+        processingDepth: 'summary',
+        content: email.subject + '\n' + email.snippet,
+        metadata: {
+          subject: email.subject,
+          from: email.from.email,
+          receivedAt: email.receivedAt
+        }
+      });
+    }
+  }
+
+  private async createEmailObject(email: Email): Promise<string> {
+    const obj = await this.objectModel.create({
+      objectType: 'email',
+      sourceUri: 'gmail:' + email.id,
+      title: email.subject,
+      status: 'parsed',
+      parsedContentJson: JSON.stringify(email),
+      cleanedText: email.body,
+      summary: email.snippet,
+      parsedAt: new Date()
+    } as any);
+    return obj.id;
+  }
+}

--- a/services/ingestion/IngestionQueueService.ts
+++ b/services/ingestion/IngestionQueueService.ts
@@ -12,6 +12,8 @@ import { UrlIngestionWorker } from './UrlIngestionWorker';
 import { PdfIngestionWorker } from './PdfIngestionWorker';
 import { IngestionAiService } from './IngestionAIService';
 import { PdfIngestionService } from './PdfIngestionService';
+import { GmailIngestionWorker } from './GmailIngestionWorker';
+import { GmailIngestionService } from './GmailIngestionService';
 import { NotFoundError } from '../base/ServiceError';
 import type { BrowserWindow } from 'electron';
 
@@ -34,6 +36,7 @@ interface IngestionQueueServiceDeps extends BaseServiceDependencies {
   vectorModel: IVectorStoreModel;
   ingestionAiService: IngestionAiService;
   pdfIngestionService: PdfIngestionService;
+  gmailIngestionService: GmailIngestionService;
   mainWindow?: BrowserWindow;
 }
 
@@ -79,10 +82,19 @@ export class IngestionQueueService extends BaseService<IngestionQueueServiceDeps
       this.deps.ingestionJobModel,
       this.deps.mainWindow
     );
-    
+
+    const gmailWorker = new GmailIngestionWorker(
+      this.deps.gmailIngestionService,
+      this.deps.objectModel,
+      this.deps.chunkSqlModel,
+      this.deps.vectorModel as any,
+      this.deps.ingestionJobModel
+    );
+
     // Register workers as job processors
     this.registerProcessor('url', urlWorker.execute.bind(urlWorker));
     this.registerProcessor('pdf', pdfWorker.execute.bind(pdfWorker));
+    this.registerProcessor('email', gmailWorker.execute.bind(gmailWorker));
     
     this.logInfo('Workers registered successfully');
   }

--- a/shared/ipcChannels.ts
+++ b/shared/ipcChannels.ts
@@ -198,6 +198,13 @@ export const PDF_INGEST_BATCH_COMPLETE = 'pdf:ingest:batch-complete';
 /** Renderer -> Main: Cancel ongoing PDF ingestion. */
 export const PDF_INGEST_CANCEL = 'pdf:ingest:cancel';
 
+// --- Gmail Integration Channels ---
+export const GMAIL_AUTH_URL = 'gmail:auth:url';
+export const GMAIL_AUTH_CALLBACK = 'gmail:auth:callback';
+export const GMAIL_AUTH_STATUS = 'gmail:auth:status';
+export const GMAIL_SYNC = 'gmail:sync';
+export const GMAIL_SYNC_STATUS = 'gmail:sync:status';
+
 // --- Object Operations ---
 /** Renderer -> Main: Get an object by its ID. */
 export const OBJECT_GET_BY_ID = 'object:getById';

--- a/shared/schemas/emailSchema.ts
+++ b/shared/schemas/emailSchema.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+
+export const EmailAddressSchema = z.object({
+  name: z.string().optional(),
+  email: z.string().email()
+});
+
+export const AttachmentSchema = z.object({
+  filename: z.string(),
+  mimeType: z.string(),
+  size: z.number()
+});
+
+export const EmailSchema = z.object({
+  id: z.string(),
+  threadId: z.string(),
+  from: EmailAddressSchema,
+  to: z.array(EmailAddressSchema),
+  cc: z.array(EmailAddressSchema).optional(),
+  bcc: z.array(EmailAddressSchema).optional(),
+  subject: z.string(),
+  snippet: z.string(),
+  body: z.string(),
+  receivedAt: z.coerce.date(),
+  labels: z.array(z.string()).optional(),
+  attachments: z.array(AttachmentSchema).optional(),
+  headers: z.record(z.string())
+});
+
+export type Email = z.infer<typeof EmailSchema>;

--- a/shared/types/email.types.ts
+++ b/shared/types/email.types.ts
@@ -1,0 +1,15 @@
+export interface Email {
+  id: string;
+  threadId: string;
+  from: { name?: string; email: string };
+  to: Array<{ name?: string; email: string }>;
+  cc?: Array<{ name?: string; email: string }>;
+  bcc?: Array<{ name?: string; email: string }>;
+  subject: string;
+  snippet: string;
+  body: string;
+  receivedAt: Date;
+  labels?: string[];
+  attachments?: Array<{ filename: string; mimeType: string; size: number }>;
+  headers: Record<string, string>;
+}

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -13,6 +13,7 @@ export * from './search.types';
 export * from './profile.types';
 export * from './todo.types';
 export * from './ingestion.types';
+export * from './email.types';
 
 // UI types
 export * from './window.types';

--- a/shared/types/ingestion.types.ts
+++ b/shared/types/ingestion.types.ts
@@ -1,5 +1,5 @@
 /** Job types for ingestion queue. */
-export type JobType = 'pdf' | 'url' | 'text_snippet';
+export type JobType = 'pdf' | 'url' | 'text_snippet' | 'email';
 
 /** Status of an ingestion job. */
 export type JobStatus = 

--- a/shared/types/vector.types.ts
+++ b/shared/types/vector.types.ts
@@ -8,7 +8,7 @@
  * Standardized media types used across the system.
  * These values must match the CHECK constraint in the SQLite objects table.
  */
-export type MediaType = 'webpage' | 'pdf' | 'notebook' | 'note' | 'tab_group' | 'image';
+export type MediaType = 'webpage' | 'pdf' | 'notebook' | 'note' | 'tab_group' | 'image' | 'email';
 
 /**
  * Base type for all vector records in LanceDB.


### PR DESCRIPTION
## Summary
- enable Gmail integration types and errors
- add Gmail auth/ingestion services and worker
- hook Gmail ingest worker into queue and Electron bootstrap
- expose Gmail IPC channels
- document environment variables
- include googleapis dependencies

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68608e2711588323a32b44c66ff90b59