### PR TITLE
Add Gmail ingestion skeleton

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+OPENAI_API_KEY=your_openai_api_key
+EXA_API_KEY=your_exa_api_key
+BROWSERBASE_API_KEY=your_key
+GMAIL_CLIENT_ID=your_client_id
+GMAIL_CLIENT_SECRET=your_client_secret
+GMAIL_REDIRECT_URI=http://localhost:3000/gmail/callback

--- a/electron/bootstrap/registerIpcHandlers.ts
+++ b/electron/bootstrap/registerIpcHandlers.ts
@@ -45,6 +45,7 @@ import { registerClassicBrowserSetBackgroundColorHandler } from '../ipc/classicB
 import { registerSyncWindowStackOrderHandler } from '../ipc/syncWindowStackOrder';
 import { registerAudioHandlers } from '../ipc/audioHandlers';
 import { registerWOMHandlers } from '../ipc/womHandlers';
+import { registerGmailHandlers } from '../ipc/gmailHandlers';
 
 export function registerAllIpcHandlers(
   serviceRegistry: ServiceRegistry,
@@ -193,6 +194,13 @@ export function registerAllIpcHandlers(
     logger.info('[IPC] PDF ingestion IPC handlers registered.');
   } else {
     logger.warn('[IPC] PdfIngestionService or mainWindow instance not available, skipping its IPC handler registration.');
+  }
+
+  if (serviceRegistry.gmailAuth && ingestionQueueService) {
+    registerGmailHandlers(ipcMain, serviceRegistry);
+    logger.info('[IPC] Gmail handlers registered.');
+  } else {
+    logger.warn('[IPC] Gmail services not available, Gmail handlers not registered.');
   }
   
   // Register debug handlers (only in development)

--- a/electron/ipc/gmailHandlers.ts
+++ b/electron/ipc/gmailHandlers.ts
@@ -1,0 +1,25 @@
+import { IpcMain } from 'electron';
+import {
+  GMAIL_AUTH_URL,
+  GMAIL_AUTH_CALLBACK,
+  GMAIL_SYNC
+} from '../../shared/ipcChannels';
+import { ServiceRegistry } from '../bootstrap/serviceBootstrap';
+
+export function registerGmailHandlers(ipcMain: IpcMain, services: ServiceRegistry) {
+  ipcMain.handle(GMAIL_AUTH_URL, () => {
+    return services.gmailAuth?.getAuthUrl();
+  });
+
+  ipcMain.handle(GMAIL_AUTH_CALLBACK, async (_e, code: string, userId: string) => {
+    if (!services.gmailAuth) return;
+    await services.gmailAuth.handleAuthCallback(code, userId);
+  });
+
+  ipcMain.handle(GMAIL_SYNC, async (_e, userId: string) => {
+    return services.ingestionQueue?.addJob('email', 'gmail', {
+      jobSpecificData: { userId, syncType: 'recent' }
+    });
+  });
+}
+

--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
     "uuid": "^11.1.0",
     "vectordb": "^0.4.0",
     "zod": "^3.25.32",
-    "zustand": "^5.0.4"
+    "zustand": "^5.0.4",
+    "googleapis": "^132.0.0"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^4.0.0",
@@ -115,6 +116,7 @@
     "@types/pdf-parse": "^1.1.4",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/google-auth-library": "^8.0.1",
     "@vitejs/plugin-react": "^4.6.0",
     "@vitest/browser": "^3.1.3",
     "@vitest/coverage-v8": "^3.1.3",

--- a/services/GmailAuthService.ts
+++ b/services/GmailAuthService.ts
@@ -1,0 +1,75 @@
+import { OAuth2Client } from 'google-auth-library';
+import type Database from 'better-sqlite3';
+import { BaseService } from './base/BaseService';
+import { GmailAuthError } from './base/ServiceError';
+import { ProfileService } from './ProfileService';
+
+interface GmailAuthServiceDeps {
+  db: Database.Database;
+  profileService: ProfileService;
+}
+
+export class GmailAuthService extends BaseService<GmailAuthServiceDeps> {
+  private oauth2Client!: OAuth2Client;
+
+  async initialize(): Promise<void> {
+    const { GMAIL_CLIENT_ID, GMAIL_CLIENT_SECRET, GMAIL_REDIRECT_URI } = process.env;
+    if (!GMAIL_CLIENT_ID || !GMAIL_CLIENT_SECRET || !GMAIL_REDIRECT_URI) {
+      throw new GmailAuthError('Missing Gmail OAuth environment variables');
+    }
+    this.oauth2Client = new OAuth2Client({
+      clientId: GMAIL_CLIENT_ID,
+      clientSecret: GMAIL_CLIENT_SECRET,
+      redirectUri: GMAIL_REDIRECT_URI
+    });
+  }
+
+  getAuthUrl(): string {
+    const scopes = ['https://www.googleapis.com/auth/gmail.readonly'];
+    return this.oauth2Client.generateAuthUrl({
+      access_type: 'offline',
+      scope: scopes,
+      prompt: 'consent'
+    });
+  }
+
+  async handleAuthCallback(code: string, userId: string): Promise<void> {
+    return this.execute('handleAuthCallback', async () => {
+      try {
+        const { tokens } = await this.oauth2Client.getToken(code);
+        // TODO: store tokens securely per userId
+        await this.saveTokens(userId, tokens);
+      } catch (error) {
+        this.logError('OAuth callback failed', error);
+        throw new GmailAuthError('Failed to exchange auth code');
+      }
+    });
+  }
+
+  private async saveTokens(userId: string, tokens: any): Promise<void> {
+    // Placeholder: use secure storage solution
+    const key = `gmail_tokens_${userId}`;
+    const stmt = this.deps.db.prepare(
+      `INSERT OR REPLACE INTO key_value_store (key, value) VALUES (?, ?)`
+    );
+    stmt.run(key, JSON.stringify(tokens));
+  }
+
+  private getTokens(userId: string): any | null {
+    const key = `gmail_tokens_${userId}`;
+    const stmt = this.deps.db.prepare(
+      `SELECT value FROM key_value_store WHERE key = ?`
+    );
+    const row = stmt.get(key) as { value: string } | undefined;
+    return row ? JSON.parse(row.value) : null;
+  }
+
+  async getAuthenticatedClient(userId: string): Promise<OAuth2Client> {
+    const tokens = this.getTokens(userId);
+    if (!tokens) {
+      throw new GmailAuthError('No stored tokens for user');
+    }
+    this.oauth2Client.setCredentials(tokens);
+    return this.oauth2Client;
+  }
+}

--- a/services/base/ServiceError.ts
+++ b/services/base/ServiceError.ts
@@ -69,6 +69,27 @@ export class ExternalServiceError extends ServiceError {
   }
 }
 
+export class GmailAuthError extends ExternalServiceError {
+  constructor(message: string) {
+    super('Gmail', message);
+    this.name = 'GmailAuthError';
+  }
+}
+
+export class GmailRateLimitError extends ExternalServiceError {
+  constructor(message: string) {
+    super('Gmail', message);
+    this.name = 'GmailRateLimitError';
+  }
+}
+
+export class GmailQuotaExceededError extends ExternalServiceError {
+  constructor(message: string) {
+    super('Gmail', message);
+    this.name = 'GmailQuotaExceededError';
+  }
+}
+
 /**
  * Error thrown when a database operation fails
  */

--- a/services/ingestion/GmailIngestionService.ts
+++ b/services/ingestion/GmailIngestionService.ts
@@ -1,0 +1,96 @@
+import { google, gmail_v1 } from 'googleapis';
+import { BaseService } from '../base/BaseService';
+import { GmailAuthService } from '../GmailAuthService';
+import { Email } from '../../shared/types';
+
+interface GmailIngestionServiceDeps {
+  gmailAuthService: GmailAuthService;
+}
+
+export class GmailIngestionService extends BaseService<GmailIngestionServiceDeps> {
+  async fetchRecentEmails(userId: string, maxResults = 50): Promise<Email[]> {
+    return this.execute('fetchRecentEmails', async () => {
+      const auth = await this.deps.gmailAuthService.getAuthenticatedClient(userId);
+      const gmail = google.gmail({ version: 'v1', auth });
+
+      const res = await gmail.users.messages.list({ userId: 'me', maxResults });
+      const messages = res.data.messages || [];
+
+      const emails: Email[] = [];
+      for (const msg of messages) {
+        if (!msg.id) continue;
+        const detail = await gmail.users.messages.get({ userId: 'me', id: msg.id });
+        const email = this.transformMessage(detail.data);
+        emails.push(email);
+      }
+      return emails;
+    });
+  }
+
+  async fetchEmailsSince(userId: string, since: Date): Promise<Email[]> {
+    const q = `after:${Math.floor(since.getTime() / 1000)}`;
+    return this.execute('fetchEmailsSince', async () => {
+      const auth = await this.deps.gmailAuthService.getAuthenticatedClient(userId);
+      const gmail = google.gmail({ version: 'v1', auth });
+      const res = await gmail.users.messages.list({ userId: 'me', q });
+      const msgs = res.data.messages || [];
+      const emails: Email[] = [];
+      for (const msg of msgs) {
+        if (!msg.id) continue;
+        const detail = await gmail.users.messages.get({ userId: 'me', id: msg.id });
+        emails.push(this.transformMessage(detail.data));
+      }
+      return emails;
+    });
+  }
+
+  private transformMessage(msg: gmail_v1.Schema$Message): Email {
+    const payload = msg.payload;
+    const headers: Record<string, string> = {};
+    payload?.headers?.forEach(h => {
+      if (h.name && h.value) headers[h.name] = h.value;
+    });
+
+    const body = this.parseEmailBody(payload);
+    const getAddress = (raw?: string): { name?: string; email: string } | null => {
+      if (!raw) return null;
+      const [namePart, emailPart] = raw.split('<');
+      const email = emailPart ? emailPart.replace('>', '').trim() : namePart.trim();
+      const name = emailPart ? namePart.trim().replace(/"/g, '') : undefined;
+      return { name, email };
+    };
+
+    const parseList = (raw?: string) =>
+      raw ? raw.split(',').map(a => getAddress(a.trim())).filter(Boolean) as Array<{name?:string;email:string}> : [];
+
+    return {
+      id: msg.id!,
+      threadId: msg.threadId || '',
+      from: getAddress(headers['From'] || '')!,
+      to: parseList(headers['To'])[0] ? parseList(headers['To']) : [],
+      cc: parseList(headers['Cc']),
+      bcc: parseList(headers['Bcc']),
+      subject: headers['Subject'] || '',
+      snippet: msg.snippet || '',
+      body,
+      receivedAt: msg.internalDate ? new Date(Number(msg.internalDate)) : new Date(),
+      labels: msg.labelIds || [],
+      attachments: payload?.parts?.filter(p => p.filename).map(p => ({ filename: p.filename!, mimeType: p.mimeType || '', size: Number(p.body?.size) || 0 })) || [],
+      headers
+    };
+  }
+
+  private parseEmailBody(payload?: gmail_v1.Schema$MessagePart): string {
+    if (!payload) return '';
+    if (payload.body && payload.body.data) {
+      return Buffer.from(payload.body.data, 'base64').toString('utf-8');
+    }
+    if (payload.parts) {
+      for (const part of payload.parts) {
+        const result = this.parseEmailBody(part);
+        if (result) return result;
+      }
+    }
+    return '';
+  }
+}

--- a/services/ingestion/GmailIngestionWorker.ts
+++ b/services/ingestion/GmailIngestionWorker.ts
@@ -1,0 +1,69 @@
+import { BaseIngestionWorker } from './BaseIngestionWorker';
+import { IngestionJob } from '../../models/IngestionJobModel';
+import { GmailIngestionService } from './GmailIngestionService';
+import { ObjectModel } from '../../models/ObjectModel';
+import { ChunkSqlModel } from '../../models/ChunkModel';
+import { LanceVectorModel } from '../../models/LanceVectorModel';
+import { Email } from '../../shared/types';
+import { v4 as uuidv4 } from 'uuid';
+
+export class GmailIngestionWorker extends BaseIngestionWorker {
+  protected objectModel: ObjectModel;
+
+  constructor(
+    private gmailService: GmailIngestionService,
+    objectModel: ObjectModel,
+    private chunkModel: ChunkSqlModel,
+    private vectorModel: LanceVectorModel,
+    ingestionJobModel: any
+  ) {
+    super(ingestionJobModel, 'GmailIngestionWorker');
+    this.objectModel = objectModel;
+  }
+
+  async execute(job: IngestionJob): Promise<void> {
+    const { userId } = job.jobSpecificData || {};
+    if (!userId) return;
+    const emails = await this.gmailService.fetchRecentEmails(userId);
+    for (const email of emails) {
+      await this.createEmailObject(email);
+    }
+  }
+
+  private async createEmailObject(email: Email): Promise<string> {
+    const obj = await this.objectModel.create({
+      objectType: 'email',
+      sourceUri: null,
+      title: email.subject,
+      status: 'parsed',
+      rawContentRef: null,
+      parsedContentJson: null,
+      cleanedText: email.body,
+      errorInfo: null,
+      parsedAt: email.receivedAt,
+      summary: null,
+      propositionsJson: null,
+      tagsJson: null,
+      summaryGeneratedAt: null
+    });
+
+    await this.vectorModel.addDocumentsWithText(
+      [`${email.subject}\n${email.snippet}`],
+      [{
+        id: uuidv4(),
+        objectId: obj.id,
+        layer: 'wom',
+        recordType: 'object',
+        mediaType: 'email',
+        processingDepth: 'summary',
+        createdAt: Date.now(),
+        title: email.subject,
+        summary: '',
+        sourceUri: '',
+        tags: [],
+        propositions: [],
+      }]
+    );
+    return obj.id;
+  }
+}

--- a/shared/ipcChannels.ts
+++ b/shared/ipcChannels.ts
@@ -198,6 +198,13 @@ export const PDF_INGEST_BATCH_COMPLETE = 'pdf:ingest:batch-complete';
 /** Renderer -> Main: Cancel ongoing PDF ingestion. */
 export const PDF_INGEST_CANCEL = 'pdf:ingest:cancel';
 
+// --- Gmail Integration ---
+export const GMAIL_AUTH_URL = 'gmail:auth:url';
+export const GMAIL_AUTH_CALLBACK = 'gmail:auth:callback';
+export const GMAIL_AUTH_STATUS = 'gmail:auth:status';
+export const GMAIL_SYNC = 'gmail:sync';
+export const GMAIL_SYNC_STATUS = 'gmail:sync:status';
+
 // --- Object Operations ---
 /** Renderer -> Main: Get an object by its ID. */
 export const OBJECT_GET_BY_ID = 'object:getById';

--- a/shared/schemas/emailSchema.ts
+++ b/shared/schemas/emailSchema.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+
+export const EmailAddressSchema = z.object({
+  name: z.string().optional(),
+  email: z.string().email()
+});
+
+export const AttachmentSchema = z.object({
+  filename: z.string(),
+  mimeType: z.string(),
+  size: z.number()
+});
+
+export const EmailSchema = z.object({
+  id: z.string(),
+  threadId: z.string(),
+  from: EmailAddressSchema,
+  to: z.array(EmailAddressSchema),
+  cc: z.array(EmailAddressSchema).optional(),
+  bcc: z.array(EmailAddressSchema).optional(),
+  subject: z.string(),
+  snippet: z.string(),
+  body: z.string(),
+  receivedAt: z.coerce.date(),
+  labels: z.array(z.string()).optional(),
+  attachments: z.array(AttachmentSchema).optional(),
+  headers: z.record(z.string())
+});
+
+export type Email = z.infer<typeof EmailSchema>;

--- a/shared/types/email.types.ts
+++ b/shared/types/email.types.ts
@@ -1,0 +1,15 @@
+export interface Email {
+  id: string;
+  threadId: string;
+  from: { name?: string; email: string };
+  to: Array<{ name?: string; email: string }>;
+  cc?: Array<{ name?: string; email: string }>;
+  bcc?: Array<{ name?: string; email: string }>;
+  subject: string;
+  snippet: string;
+  body: string;
+  receivedAt: Date;
+  labels?: string[];
+  attachments?: Array<{ filename: string; mimeType: string; size: number }>;
+  headers: Record<string, string>;
+}

--- a/shared/types/index.ts
+++ b/shared/types/index.ts
@@ -27,3 +27,4 @@ export * from './store.types';
 
 // Streaming types
 export * from './stream.types';
+export * from './email.types';

--- a/shared/types/ingestion.types.ts
+++ b/shared/types/ingestion.types.ts
@@ -1,5 +1,5 @@
 /** Job types for ingestion queue. */
-export type JobType = 'pdf' | 'url' | 'text_snippet';
+export type JobType = 'pdf' | 'url' | 'text_snippet' | 'email';
 
 /** Status of an ingestion job. */
 export type JobStatus = 


### PR DESCRIPTION
## Summary
- add Gmail ingestion types and schemas
- implement `GmailAuthService`, `GmailIngestionService`, and `GmailIngestionWorker`
- support new `email` job type in `IngestionQueueService`
- register Gmail services and IPC handlers
- expose new Gmail IPC channels
- document Gmail env vars

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: missing vitest type defs)*

------
https://chatgpt.com/codex/tasks/task_e_68608e2711588323a32b44c66ff90b59