### PR TITLE
refactor: remove redundant 'Sql' suffix from model names

### DIFF
--- a/electron/bootstrap/modelBootstrap.ts
+++ b/electron/bootstrap/modelBootstrap.ts
@@ -4,12 +4,12 @@ import { app } from 'electron';
 import * as fs from 'fs';
 import * as path from 'path';
 import { ObjectModel } from '../../models/ObjectModel';
-import { ChunkSqlModel } from '../../models/ChunkModel';
+import { ChunkModel } from '../../models/ChunkModel';
 import { LanceVectorModel } from '../../models/LanceVectorModel';
 import { ChatModel } from '../../models/ChatModel';
 import { NotebookModel } from '../../models/NotebookModel';
 import { NoteModel } from '../../models/NoteModel';
-import { EmbeddingSqlModel } from '../../models/EmbeddingModel';
+import { EmbeddingModel } from '../../models/EmbeddingModel';
 import { IngestionJobModel } from '../../models/IngestionJobModel';
 import { UserProfileModel } from '../../models/UserProfileModel';
 import { ToDoModel } from '../../models/ToDoModel';
@@ -21,12 +21,12 @@ import { ActivityLogModel } from '../../models/ActivityLogModel';
 export interface ModelRegistry {
   // Core models
   objectModel: ObjectModel;
-  chunkSqlModel: ChunkSqlModel;
+  chunkModel: ChunkModel;
   vectorModel: LanceVectorModel;
   chatModel: ChatModel;
   notebookModel: NotebookModel;
   noteModel: NoteModel;
-  embeddingSqlModel: EmbeddingSqlModel;
+  embeddingModel: EmbeddingModel;
   ingestionJobModel: IngestionJobModel;
   userProfileModel: UserProfileModel;
   toDoModel: ToDoModel;
@@ -47,8 +47,8 @@ export default async function initModels(db: Database.Database, userDataPath?: s
   const objectModel = new ObjectModel(db);
   logger.info('[ModelBootstrap] ObjectModel instantiated.');
   
-  const chunkSqlModel = new ChunkSqlModel(db);
-  logger.info('[ModelBootstrap] ChunkSqlModel instantiated.');
+  const chunkModel = new ChunkModel(db);
+  logger.info('[ModelBootstrap] ChunkModel instantiated.');
   
   const notebookModel = new NotebookModel(db);
   logger.info('[ModelBootstrap] NotebookModel instantiated.');
@@ -56,8 +56,8 @@ export default async function initModels(db: Database.Database, userDataPath?: s
   const noteModel = new NoteModel(db);
   logger.info('[ModelBootstrap] NoteModel instantiated.');
   
-  const embeddingSqlModel = new EmbeddingSqlModel(db);
-  logger.info('[ModelBootstrap] EmbeddingSqlModel instantiated.');
+  const embeddingModel = new EmbeddingModel(db);
+  logger.info('[ModelBootstrap] EmbeddingModel instantiated.');
   
   const vectorModel = new LanceVectorModel({
     userDataPath: userDataPath || app.getPath('userData')
@@ -96,12 +96,12 @@ export default async function initModels(db: Database.Database, userDataPath?: s
   
   return {
     objectModel,
-    chunkSqlModel,
+    chunkModel,
     vectorModel,
     chatModel,
     notebookModel,
     noteModel,
-    embeddingSqlModel,
+    embeddingModel,
     ingestionJobModel,
     userProfileModel,
     toDoModel,

--- a/electron/bootstrap/serviceBootstrap.ts
+++ b/electron/bootstrap/serviceBootstrap.ts
@@ -303,7 +303,7 @@ export async function initializeServices(
     logger.info('[ServiceBootstrap] Initializing Phase 3 services...');
     
     // Get additional models needed for Phase 3 services
-    const { chatModel, notebookModel, noteModel, chunkSqlModel } = models;
+    const { chatModel, notebookModel, noteModel, chunkModel } = models;
     
     // Initialize LangchainAgent (depends on vector model, ChatModel, and ProfileService)
     const langchainAgent = await createService('LangchainAgent', LangchainAgent, [{
@@ -333,17 +333,17 @@ export async function initializeServices(
       db: deps.db,
       notebookModel,
       objectModel,
-      chunkSqlModel,
+      chunkModel,
       chatModel,
       activityLogService,
       activityLogModel
     }]);
     registry.notebook = notebookService;
     
-    // Initialize SliceService (depends on ChunkSqlModel and ObjectModel)
+    // Initialize SliceService (depends on ChunkModel and ObjectModel)
     const sliceService = await createService('SliceService', SliceService, [{
       db: deps.db,
-      chunkSqlModel,
+      chunkModel,
       objectModel
     }]);
     registry.slice = sliceService;
@@ -358,15 +358,15 @@ export async function initializeServices(
       noteModel
     }]);
     
-    // Get embeddingSqlModel from models (needed by ObjectService and later by ChunkingService)
-    const { embeddingSqlModel } = models;
+    // Get embeddingModel from models (needed by ObjectService and later by ChunkingService)
+    const { embeddingModel } = models;
     
     // Initialize ObjectService (depends on models and vector model)
     registry.object = await createService('ObjectService', ObjectService, [{
       db: deps.db,
       objectModel,
-      chunkModel: chunkSqlModel,
-      embeddingModel: embeddingSqlModel,
+      chunkModel: chunkModel,
+      embeddingModel: embeddingModel,
       vectorModel: vectorModel
     }]);
     
@@ -442,7 +442,7 @@ export async function initializeServices(
       toDoService,
       profileService,
       objectModel,
-      chunkSqlModel
+      chunkModel
     }]);
     
     // Phase 5: Continue with remaining ingestion services
@@ -460,8 +460,8 @@ export async function initializeServices(
       vectorStore: vectorModel,
       ingestionAiService,
       objectModel,
-      chunkSqlModel,
-      embeddingSqlModel,
+      chunkModel,
+      embeddingModel,
       ingestionJobModel
     }]);
     registry.chunking = chunkingService;
@@ -471,8 +471,8 @@ export async function initializeServices(
       db: deps.db,
       ingestionJobModel,
       objectModel: objectModel!,
-      chunkSqlModel,
-      embeddingSqlModel,
+      chunkModel,
+      embeddingModel,
       vectorModel,
       ingestionAiService,
       pdfIngestionService,

--- a/electron/ipc/objectHandlers.ts
+++ b/electron/ipc/objectHandlers.ts
@@ -55,8 +55,8 @@ export function registerObjectHandlers(
         const objectService = new ObjectService({
           db,
           objectModel,
-          chunkModel: new (await import('../../models/ChunkModel')).ChunkSqlModel(db),
-          embeddingModel: new (await import('../../models/EmbeddingModel')).EmbeddingSqlModel(db),
+          chunkModel: new (await import('../../models/ChunkModel')).ChunkModel(db),
+          embeddingModel: new (await import('../../models/EmbeddingModel')).EmbeddingModel(db),
           vectorModel: new (await import('../../models/LanceVectorModel')).LanceVectorModel({ 
             userDataPath: require('electron').app.getPath('userData')
           })
@@ -102,8 +102,8 @@ export function registerObjectHandlers(
         const objectService = new ObjectService({
           db,
           objectModel,
-          chunkModel: new (await import('../../models/ChunkModel')).ChunkSqlModel(db),
-          embeddingModel: new (await import('../../models/EmbeddingModel')).EmbeddingSqlModel(db),
+          chunkModel: new (await import('../../models/ChunkModel')).ChunkModel(db),
+          embeddingModel: new (await import('../../models/EmbeddingModel')).EmbeddingModel(db),
           vectorModel: new (await import('../../models/LanceVectorModel')).LanceVectorModel({ 
             userDataPath: require('electron').app.getPath('userData')
           })

--- a/junkDrawer/reembed.ts
+++ b/junkDrawer/reembed.ts
@@ -70,8 +70,8 @@ async function main() {
       vectorStore: models.vectorModel, // This is now LanceVectorModel
       ingestionAiService,
       objectModel: models.objectModel,
-      chunkSqlModel: models.chunkSqlModel,
-      embeddingSqlModel: models.embeddingSqlModel,
+      chunkModel: models.chunkModel,
+      embeddingModel: models.embeddingModel,
       ingestionJobModel: models.ingestionJobModel
     });
     

--- a/models/ChunkModel.ts
+++ b/models/ChunkModel.ts
@@ -36,11 +36,11 @@ function mapRecordToChunk(record: ChunkRecord): ObjectChunk {
 // Type for data needed to create a chunk (SQL layer)
 export type ChunkData = Omit<ObjectChunk, 'id' | 'createdAt'> & { objectId: string, notebookId?: string | null };
 
-export class ChunkSqlModel {
+export class ChunkModel {
     private db: Database.Database; // Add private db instance variable
 
     /**
-     * Creates an instance of ChunkSqlModel.
+     * Creates an instance of ChunkModel.
      * @param dbInstance - An initialized better-sqlite3 database instance.
      */
     constructor(dbInstance: Database.Database) {
@@ -73,7 +73,7 @@ export class ChunkSqlModel {
             });
 
             const newId = info.lastInsertRowid as number;
-            logger.debug(`[ChunkSqlModel] Added chunk with ID: ${newId} for object ${data.objectId}`);
+            logger.debug(`[ChunkModel] Added chunk with ID: ${newId} for object ${data.objectId}`);
 
             // Fetch and return the newly created chunk
             const newRecord = this.getById(newId);
@@ -84,7 +84,7 @@ export class ChunkSqlModel {
             return newRecord;
 
         } catch (error) {
-            logger.error(`[ChunkSqlModel] Failed to add chunk for object ${data.objectId}, index ${data.chunkIdx}:`, error);
+            logger.error(`[ChunkModel] Failed to add chunk for object ${data.objectId}, index ${data.chunkIdx}:`, error);
             throw error;
         }
     }
@@ -117,7 +117,7 @@ export class ChunkSqlModel {
             });
 
             const newId = info.lastInsertRowid as number;
-            logger.debug(`[ChunkSqlModel] Added chunk synchronously with ID: ${newId} for object ${data.objectId}`);
+            logger.debug(`[ChunkModel] Added chunk synchronously with ID: ${newId} for object ${data.objectId}`);
 
             // getById is already synchronous, so we can use it directly
             const newRecord = this.getById(newId);
@@ -128,7 +128,7 @@ export class ChunkSqlModel {
             return newRecord;
 
         } catch (error) {
-            logger.error(`[ChunkSqlModel] Failed to add chunk synchronously for object ${data.objectId}, index ${data.chunkIdx}:`, error);
+            logger.error(`[ChunkModel] Failed to add chunk synchronously for object ${data.objectId}, index ${data.chunkIdx}:`, error);
             throw error;
         }
     }
@@ -168,10 +168,10 @@ export class ChunkSqlModel {
 
         try {
             const result = await insertMany(chunks);
-            logger.debug(`[ChunkSqlModel] Bulk added ${insertedIds.length} chunks for object ${chunks[0]?.objectId}`);
+            logger.debug(`[ChunkModel] Bulk added ${insertedIds.length} chunks for object ${chunks[0]?.objectId}`);
             return insertedIds;
         } catch (error) {
-            logger.error(`[ChunkSqlModel] Failed to bulk add chunks for object ${chunks[0]?.objectId}:`, error);
+            logger.error(`[ChunkModel] Failed to bulk add chunks for object ${chunks[0]?.objectId}:`, error);
             throw error;
         }
     }
@@ -212,10 +212,10 @@ export class ChunkSqlModel {
 
         try {
             insertMany(chunks);
-            logger.debug(`[ChunkSqlModel] Bulk added ${insertedIds.length} chunks synchronously for object ${chunks[0]?.objectId}`);
+            logger.debug(`[ChunkModel] Bulk added ${insertedIds.length} chunks synchronously for object ${chunks[0]?.objectId}`);
             return insertedIds;
         } catch (error) {
-            logger.error(`[ChunkSqlModel] Failed to bulk add chunks synchronously for object ${chunks[0]?.objectId}:`, error);
+            logger.error(`[ChunkModel] Failed to bulk add chunks synchronously for object ${chunks[0]?.objectId}:`, error);
             throw error;
         }
     }
@@ -237,10 +237,10 @@ export class ChunkSqlModel {
 
         try {
             const records = stmt.all(limit) as ChunkRecord[];
-            logger.debug(`[ChunkSqlModel] Found ${records.length} unembedded chunks.`);
+            logger.debug(`[ChunkModel] Found ${records.length} unembedded chunks.`);
             return records.map(mapRecordToChunk);
         } catch (error) {
-            logger.error('[ChunkSqlModel] Failed to list unembedded chunks:', error);
+            logger.error('[ChunkModel] Failed to list unembedded chunks:', error);
             throw error;
         }
     }
@@ -256,7 +256,7 @@ export class ChunkSqlModel {
             const record = stmt.get(id) as ChunkRecord | undefined;
             return record ? mapRecordToChunk(record) : null;
         } catch (error) {
-            logger.error(`[ChunkSqlModel] Failed to get chunk by ID ${id}:`, error);
+            logger.error(`[ChunkModel] Failed to get chunk by ID ${id}:`, error);
             throw error;
         }
     }
@@ -270,10 +270,10 @@ export class ChunkSqlModel {
         const stmt = this.db.prepare('SELECT * FROM chunks WHERE object_id = ? ORDER BY chunk_idx ASC');
         try {
             const records = stmt.all(objectId) as ChunkRecord[];
-            logger.debug(`[ChunkSqlModel] Found ${records.length} chunks for object ${objectId}.`);
+            logger.debug(`[ChunkModel] Found ${records.length} chunks for object ${objectId}.`);
             return records.map(mapRecordToChunk);
         } catch (error) {
-            logger.error(`[ChunkSqlModel] Failed to list chunks for object ${objectId}:`, error);
+            logger.error(`[ChunkModel] Failed to list chunks for object ${objectId}:`, error);
             throw error;
         }
     }
@@ -287,10 +287,10 @@ export class ChunkSqlModel {
         const stmt = this.db.prepare('SELECT * FROM chunks WHERE notebook_id = ? ORDER BY chunk_idx ASC');
         try {
             const records = stmt.all(notebookId) as ChunkRecord[];
-            logger.debug(`[ChunkSqlModel] Found ${records.length} chunks for notebook ${notebookId}.`);
+            logger.debug(`[ChunkModel] Found ${records.length} chunks for notebook ${notebookId}.`);
             return records.map(mapRecordToChunk);
         } catch (error) {
-            logger.error(`[ChunkSqlModel] Failed to list chunks for notebook ${notebookId}:`, error);
+            logger.error(`[ChunkModel] Failed to list chunks for notebook ${notebookId}:`, error);
             throw error;
         }
     }
@@ -414,13 +414,13 @@ export class ChunkSqlModel {
         try {
             const result = stmt.run({ chunkId, notebookId });
             if (result.changes > 0) {
-                logger.debug(`[ChunkSqlModel] Assigned chunk ${chunkId} to notebook ${notebookId}`);
+                logger.debug(`[ChunkModel] Assigned chunk ${chunkId} to notebook ${notebookId}`);
                 return true;
             }
-            logger.warn(`[ChunkSqlModel] No chunk found with ID ${chunkId} to assign to notebook, or notebook_id was already set to that value.`);
+            logger.warn(`[ChunkModel] No chunk found with ID ${chunkId} to assign to notebook, or notebook_id was already set to that value.`);
             return false;
         } catch (error) {
-            logger.error(`[ChunkSqlModel] Error assigning chunk ${chunkId} to notebook ${notebookId}:`, error);
+            logger.error(`[ChunkModel] Error assigning chunk ${chunkId} to notebook ${notebookId}:`, error);
             throw error;
         }
     }
@@ -439,10 +439,10 @@ export class ChunkSqlModel {
 
         try {
             const records = stmt.all(objectId) as ChunkRecord[];
-            logger.debug(`[ChunkSqlModel] Found ${records.length} chunks for object ${objectId}.`);
+            logger.debug(`[ChunkModel] Found ${records.length} chunks for object ${objectId}.`);
             return records.map(mapRecordToChunk);
         } catch (error) {
-            logger.error(`[ChunkSqlModel] Failed to get chunks for object ${objectId}:`, error);
+            logger.error(`[ChunkModel] Failed to get chunks for object ${objectId}:`, error);
             throw error;
         }
     }
@@ -471,14 +471,14 @@ export class ChunkSqlModel {
                 const chunkIds = rows.map(row => row.id.toString());
                 allChunkIds.push(...chunkIds);
                 
-                logger.debug(`[ChunkSqlModel] Found ${chunkIds.length} chunks for batch of ${batch.length} objects`);
+                logger.debug(`[ChunkModel] Found ${chunkIds.length} chunks for batch of ${batch.length} objects`);
             } catch (error) {
-                logger.error('[ChunkSqlModel] Failed to get chunk IDs by object IDs:', error);
+                logger.error('[ChunkModel] Failed to get chunk IDs by object IDs:', error);
                 throw error;
             }
         }
 
-        logger.info(`[ChunkSqlModel] Found ${allChunkIds.length} total chunks for ${objectIds.length} objects`);
+        logger.info(`[ChunkModel] Found ${allChunkIds.length} total chunks for ${objectIds.length} objects`);
         return allChunkIds;
     }
 
@@ -503,14 +503,14 @@ export class ChunkSqlModel {
             try {
                 const result = stmt.run(...batch);
                 totalDeleted += result.changes;
-                logger.debug(`[ChunkSqlModel] Deleted ${result.changes} chunks for batch of ${batch.length} objects`);
+                logger.debug(`[ChunkModel] Deleted ${result.changes} chunks for batch of ${batch.length} objects`);
             } catch (error) {
-                logger.error('[ChunkSqlModel] Failed to delete chunks by object IDs:', error);
+                logger.error('[ChunkModel] Failed to delete chunks by object IDs:', error);
                 throw error;
             }
         }
 
-        logger.info(`[ChunkSqlModel] Deleted ${totalDeleted} total chunks for ${objectIds.length} objects`);
+        logger.info(`[ChunkModel] Deleted ${totalDeleted} total chunks for ${objectIds.length} objects`);
     }
 
     /**
@@ -527,9 +527,9 @@ export class ChunkSqlModel {
         
         try {
             const info = stmt.run(...chunkIds);
-            logger.debug(`[ChunkSqlModel] Deleted ${info.changes} chunks`);
+            logger.debug(`[ChunkModel] Deleted ${info.changes} chunks`);
         } catch (error) {
-            logger.error('[ChunkSqlModel] Failed to delete chunks by IDs:', error);
+            logger.error('[ChunkModel] Failed to delete chunks by IDs:', error);
             throw error;
         }
     }
@@ -544,4 +544,4 @@ export class ChunkSqlModel {
 }
 
 // Export a singleton instance
-// export const chunkSqlModel = new ChunkSqlModel(); 
+// export const chunkModel = new ChunkModel(); 

--- a/services/NotebookService.ts
+++ b/services/NotebookService.ts
@@ -3,7 +3,7 @@ import Database from 'better-sqlite3';
 import { BaseService } from './base/BaseService';
 import { NotebookModel } from '../models/NotebookModel';
 import { ObjectModel } from '../models/ObjectModel';
-import { ChunkSqlModel } from '../models/ChunkModel';
+import { ChunkModel } from '../models/ChunkModel';
 import { ChatModel } from '../models/ChatModel';
 import { ActivityLogService } from './ActivityLogService';
 import { ActivityLogModel } from '../models/ActivityLogModel';
@@ -13,7 +13,7 @@ interface NotebookServiceDeps {
   db: Database.Database;
   notebookModel: NotebookModel;
   objectModel: ObjectModel;
-  chunkSqlModel: ChunkSqlModel;
+  chunkModel: ChunkModel;
   chatModel: ChatModel;
   activityLogService: ActivityLogService;
   activityLogModel: ActivityLogModel;
@@ -351,7 +351,7 @@ export class NotebookService extends BaseService<NotebookServiceDeps> {
         }
       }
       
-      const success = await this.deps.chunkSqlModel.assignToNotebook(chunkId, notebookId);
+      const success = await this.deps.chunkModel.assignToNotebook(chunkId, notebookId);
       if (success) {
         this.logger.info(`Chunk ${chunkId} assignment to notebook ${notebookId} updated in SQL.`);
       } else {
@@ -374,7 +374,7 @@ export class NotebookService extends BaseService<NotebookServiceDeps> {
         this.logger.error(`Notebook ${notebookId} not found when getting chunks.`);
         throw new Error(`Notebook not found with ID: ${notebookId}`);
       }
-      return this.deps.chunkSqlModel.listByNotebookId(notebookId);
+      return this.deps.chunkModel.listByNotebookId(notebookId);
     });
   }
 

--- a/services/ObjectService.ts
+++ b/services/ObjectService.ts
@@ -1,7 +1,7 @@
 import { Database } from 'better-sqlite3';
 import { ObjectModel } from '../models/ObjectModel';
-import { ChunkSqlModel } from '../models/ChunkModel';
-import { EmbeddingSqlModel } from '../models/EmbeddingModel';
+import { ChunkModel } from '../models/ChunkModel';
+import { EmbeddingModel } from '../models/EmbeddingModel';
 import { IVectorStoreModel } from '../shared/types/vector.types';
 import { DeleteResult } from '../shared/types';
 import { logger } from '../utils/logger';
@@ -10,8 +10,8 @@ import { BaseService } from './base/BaseService';
 interface ObjectServiceDeps {
   db: Database;
   objectModel: ObjectModel;
-  chunkModel: ChunkSqlModel;
-  embeddingModel: EmbeddingSqlModel;
+  chunkModel: ChunkModel;
+  embeddingModel: EmbeddingModel;
   vectorModel: IVectorStoreModel;
 }
 

--- a/services/SliceService.ts
+++ b/services/SliceService.ts
@@ -1,11 +1,11 @@
-import { ChunkSqlModel } from "../models/ChunkModel";
+import { ChunkModel } from "../models/ChunkModel";
 import { ObjectModel, SourceMetadata } from "../models/ObjectModel";
 import { ObjectChunk, SliceDetail } from "../shared/types";
 import { BaseService } from './base/BaseService';
 import { BaseServiceDependencies } from './interfaces';
 
 interface SliceServiceDeps extends BaseServiceDependencies {
-    chunkSqlModel: ChunkSqlModel;
+    chunkModel: ChunkModel;
     objectModel: ObjectModel;
 }
 
@@ -33,12 +33,12 @@ export class SliceService extends BaseService<SliceServiceDeps> {
             this.logInfo(`getDetailsForSlices called with ${chunkIds.length} chunk IDs`);
             this.logDebug(`Chunk IDs: [${chunkIds.join(', ')}]`);
             // 1. Fetch chunk data from SQL model
-            // Convert number[] to string[] as ChunkSqlModel.getChunksByIds currently expects strings
+            // Convert number[] to string[] as ChunkModel.getChunksByIds currently expects strings
             const chunkIdStrings = chunkIds.map(id => String(id));
             this.logDebug(`Converted to string IDs: [${chunkIdStrings.join(', ')}]`);
             
-            const chunks: ObjectChunk[] = await this.deps.chunkSqlModel.getChunksByIds(chunkIdStrings);
-            this.logInfo(`ChunkSqlModel returned ${chunks.length} chunks`);
+            const chunks: ObjectChunk[] = await this.deps.chunkModel.getChunksByIds(chunkIdStrings);
+            this.logInfo(`ChunkModel returned ${chunks.length} chunks`);
 
             if (chunks.length === 0) {
                 this.logWarn("No chunks found for the provided IDs. This suggests the chunks don't exist in the database.");

--- a/services/_tests/ObjectService.test.ts
+++ b/services/_tests/ObjectService.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect, beforeEach, afterEach, vi, Mock } from 'vitest';
 import Database from 'better-sqlite3';
 import { ObjectService } from '../../services/ObjectService';
 import { ObjectModel } from '../../models/ObjectModel';
-import { ChunkSqlModel } from '../../models/ChunkModel';
-import { EmbeddingSqlModel } from '../../models/EmbeddingModel';
+import { ChunkModel } from '../../models/ChunkModel';
+import { EmbeddingModel } from '../../models/EmbeddingModel';
 import { IVectorStoreModel, LanceVectorModel } from '../../shared/types/vector.types';
 import { initDb } from '../../models/db';
 import runMigrations from '../../models/runMigrations';
@@ -16,8 +16,8 @@ describe('ObjectService', () => {
   let db: Database.Database;
   let objectService: ObjectService;
   let objectModel: ObjectModel;
-  let chunkModel: ChunkSqlModel;
-  let embeddingModel: EmbeddingSqlModel;
+  let chunkModel: ChunkModel;
+  let embeddingModel: EmbeddingModel;
   let vectorModel: IVectorStoreModel;
 
   // Helper function to create test objects
@@ -78,8 +78,8 @@ describe('ObjectService', () => {
     
     // Create real model instances
     objectModel = new ObjectModel(db);
-    chunkModel = new ChunkSqlModel(db);
-    embeddingModel = new EmbeddingSqlModel(db);
+    chunkModel = new ChunkModel(db);
+    embeddingModel = new EmbeddingModel(db);
     
     // Create mocked LanceVectorModel
     vectorModel = new LanceVectorModel({ userDataPath: ':memory:' });

--- a/services/_tests/SliceService.summary.test.ts
+++ b/services/_tests/SliceService.summary.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import Database from 'better-sqlite3';
 import { SliceService } from '../SliceService';
-import { ChunkSqlModel } from '../../models/ChunkModel';
+import { ChunkModel } from '../../models/ChunkModel';
 import { ObjectModel } from '../../models/ObjectModel';
 import runMigrations from '../../models/runMigrations';
 import { v4 as uuidv4 } from 'uuid';
@@ -9,7 +9,7 @@ import { v4 as uuidv4 } from 'uuid';
 describe('SliceService - Summary Field', () => {
   let db: Database.Database;
   let sliceService: SliceService;
-  let chunkModel: ChunkSqlModel;
+  let chunkModel: ChunkModel;
   let objectModel: ObjectModel;
 
   beforeEach(async () => {
@@ -18,11 +18,11 @@ describe('SliceService - Summary Field', () => {
     await runMigrations(db);
 
     // Initialize models and service
-    chunkModel = new ChunkSqlModel(db);
+    chunkModel = new ChunkModel(db);
     objectModel = new ObjectModel(db);
     sliceService = new SliceService({
       db,
-      chunkSqlModel: chunkModel,
+      chunkModel: chunkModel,
       objectModel: objectModel
     });
   });

--- a/services/_tests/SliceService.test.ts
+++ b/services/_tests/SliceService.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { SliceService } from '../SliceService';
-import type { ChunkSqlModel } from '../../models/ChunkModel';
+import type { ChunkModel } from '../../models/ChunkModel';
 import type { ObjectModel } from '../../models/ObjectModel';
 import type { SliceDetail } from '../../shared/types';
 import type { Database } from 'better-sqlite3';
@@ -40,7 +40,7 @@ describe('SliceService', () => {
     // Create service instance with mocked dependencies using BaseService pattern
     sliceService = new SliceService({
       db: mockDb,
-      chunkSqlModel: mockChunkModel as ChunkSqlModel,
+      chunkModel: mockChunkModel as ChunkModel,
       objectModel: mockObjectModel as ObjectModel
     });
   });

--- a/services/agents/ProfileAgent.ts
+++ b/services/agents/ProfileAgent.ts
@@ -5,7 +5,7 @@ import { ToDoService } from '../ToDoService';
 import { ProfileService } from '../ProfileService';
 import { UserProfile, UserGoalItem, InferredUserGoalItem, UserActivity, ToDoItem } from '../../shared/types';
 import { ObjectModel } from '../../models/ObjectModel';
-import { ChunkSqlModel } from '../../models/ChunkModel';
+import { ChunkModel } from '../../models/ChunkModel';
 import { 
   SynthesizedProfileDataSchema,
   ContentSynthesisDataSchema,
@@ -30,7 +30,7 @@ interface ProfileAgentDeps extends BaseServiceDependencies {
   toDoService: ToDoService;
   profileService: ProfileService;
   objectModel: ObjectModel;
-  chunkSqlModel: ChunkSqlModel;
+  chunkModel: ChunkModel;
 }
 
 export class ProfileAgent extends BaseService<ProfileAgentDeps> {
@@ -317,7 +317,7 @@ Respond ONLY with the JSON object.`;
         if (!fullObj) continue;
         
         // Get chunks for this object
-        const chunks = await this.deps.chunkSqlModel.getChunksByObjectId(obj.id);
+        const chunks = await this.deps.chunkModel.getChunksByObjectId(obj.id);
         const topChunks = chunks.slice(0, 3);
         
         const chunkTexts = topChunks.map((c) => c.content.substring(0, 200)).join(" ");

--- a/services/agents/_tests/ProfileAgent.test.ts
+++ b/services/agents/_tests/ProfileAgent.test.ts
@@ -9,7 +9,7 @@ import { UserProfileModel } from '../../../models/UserProfileModel';
 import { ActivityLogModel } from '../../../models/ActivityLogModel';
 import { ToDoModel } from '../../../models/ToDoModel';
 import { ObjectModel } from '../../../models/ObjectModel';
-import { ChunkSqlModel } from '../../../models/ChunkModel';
+import { ChunkModel } from '../../../models/ChunkModel';
 import runMigrations from '../../../models/runMigrations';
 import { ActivityType, ObjectStatus } from '../../../shared/types';
 import { BaseMessage } from '@langchain/core/messages';
@@ -36,7 +36,7 @@ describe('ProfileAgent', () => {
   let activityLogService: ActivityLogService;
   let todoService: ToDoService;
   let objectModel: ObjectModel;
-  let chunkModel: ChunkSqlModel;
+  let chunkModel: ChunkModel;
 
   beforeEach(async () => {
     // Reset all mocks before each test
@@ -59,7 +59,7 @@ describe('ProfileAgent', () => {
     const activityLogModel = new ActivityLogModel(db);
     const todoModel = new ToDoModel(db);
     objectModel = new ObjectModel(db);
-    chunkModel = new ChunkSqlModel(db);
+    chunkModel = new ChunkModel(db);
     
     // Initialize services
     profileService = new ProfileService({ db, userProfileModel });
@@ -89,7 +89,7 @@ describe('ProfileAgent', () => {
       toDoService: todoService,
       profileService,
       objectModel,
-      chunkSqlModel: chunkModel
+      chunkModel: chunkModel
     });
   });
 

--- a/services/ingestion/IngestionQueueService.ts
+++ b/services/ingestion/IngestionQueueService.ts
@@ -1,8 +1,8 @@
 import { EventEmitter } from 'events';
 import { IngestionJobModel, IngestionJob } from '../../models/IngestionJobModel';
 import { ObjectModel } from '../../models/ObjectModel';
-import { ChunkSqlModel } from '../../models/ChunkModel';
-import { EmbeddingSqlModel } from '../../models/EmbeddingModel';
+import { ChunkModel } from '../../models/ChunkModel';
+import { EmbeddingModel } from '../../models/EmbeddingModel';
 import { IVectorStoreModel } from '../../shared/types/vector.types';
 import { JobType, JobStatus } from '../../shared/types';
 import { IIngestionWorker } from './types';
@@ -29,8 +29,8 @@ export interface JobProcessor {
 interface IngestionQueueServiceDeps extends BaseServiceDependencies {
   ingestionJobModel: IngestionJobModel;
   objectModel: ObjectModel;
-  chunkSqlModel: ChunkSqlModel;
-  embeddingSqlModel: EmbeddingSqlModel;
+  chunkModel: ChunkModel;
+  embeddingModel: EmbeddingModel;
   vectorModel: IVectorStoreModel;
   ingestionAiService: IngestionAiService;
   pdfIngestionService: PdfIngestionService;
@@ -73,8 +73,8 @@ export class IngestionQueueService extends BaseService<IngestionQueueServiceDeps
     const pdfWorker = new PdfIngestionWorker(
       this.deps.pdfIngestionService,
       this.deps.objectModel,
-      this.deps.chunkSqlModel,
-      this.deps.embeddingSqlModel,
+      this.deps.chunkModel,
+      this.deps.embeddingModel,
       this.deps.vectorModel,
       this.deps.ingestionJobModel,
       this.deps.mainWindow

--- a/services/ingestion/PdfIngestionWorker.ts
+++ b/services/ingestion/PdfIngestionWorker.ts
@@ -1,8 +1,8 @@
 import { logger } from '../../utils/logger';
 import { IngestionJob, IngestionJobModel } from '../../models/IngestionJobModel';
 import { ObjectModel } from '../../models/ObjectModel';
-import { ChunkSqlModel } from '../../models/ChunkModel';
-import { EmbeddingSqlModel } from '../../models/EmbeddingModel';
+import { ChunkModel } from '../../models/ChunkModel';
+import { EmbeddingModel } from '../../models/EmbeddingModel';
 import { IVectorStoreModel } from '../../shared/types/vector.types';
 import { PdfIngestionService, PdfProgressCallback } from './PdfIngestionService';
 import { BaseIngestionWorker } from './BaseIngestionWorker';
@@ -20,8 +20,8 @@ const EMBEDDING_MODEL_NAME = 'text-embedding-3-small';
 export class PdfIngestionWorker extends BaseIngestionWorker {
   private pdfIngestionService: PdfIngestionService;
   protected objectModel: ObjectModel;
-  private chunkSqlModel: ChunkSqlModel;
-  private embeddingSqlModel: EmbeddingSqlModel;
+  private chunkModel: ChunkModel;
+  private embeddingModel: EmbeddingModel;
   private vectorModel: IVectorStoreModel;
   private pdfStorageDir: string;
   private mainWindow?: BrowserWindow;
@@ -29,8 +29,8 @@ export class PdfIngestionWorker extends BaseIngestionWorker {
   constructor(
     pdfIngestionService: PdfIngestionService,
     objectModel: ObjectModel,
-    chunkSqlModel: ChunkSqlModel,
-    embeddingSqlModel: EmbeddingSqlModel,
+    chunkModel: ChunkModel,
+    embeddingModel: EmbeddingModel,
     vectorModel: IVectorStoreModel,
     ingestionJobModel: IngestionJobModel,
     mainWindow?: BrowserWindow
@@ -38,8 +38,8 @@ export class PdfIngestionWorker extends BaseIngestionWorker {
     super(ingestionJobModel, 'PdfIngestionWorker');
     this.pdfIngestionService = pdfIngestionService;
     this.objectModel = objectModel;
-    this.chunkSqlModel = chunkSqlModel;
-    this.embeddingSqlModel = embeddingSqlModel;
+    this.chunkModel = chunkModel;
+    this.embeddingModel = embeddingModel;
     this.vectorModel = vectorModel;
     this.mainWindow = mainWindow;
     
@@ -231,7 +231,7 @@ export class PdfIngestionWorker extends BaseIngestionWorker {
       try {
         // Create a single chunk for the entire PDF
         // This maintains compatibility with the existing embedding system
-        const chunk = await this.chunkSqlModel.addChunk({
+        const chunk = await this.chunkModel.addChunk({
           objectId: objectId,
           chunkIdx: 0, // Single chunk for PDFs
           content: aiContent.summary, // Use the summary as the chunk content

--- a/services/ingestion/_tests/ChunkingService.test.ts
+++ b/services/ingestion/_tests/ChunkingService.test.ts
@@ -18,8 +18,8 @@ describe('ChunkingService', () => {
   let mockDb: Partial<Database.Database>;
   let mockVectorStore: IVectorStore;
   let mockObjectModel: any;
-  let mockChunkSqlModel: any;
-  let mockEmbeddingSqlModel: any;
+  let mockChunkModel: any;
+  let mockEmbeddingModel: any;
   let mockIngestionJobModel: any;
   let mockAgent: any;
   
@@ -71,7 +71,7 @@ describe('ChunkingService', () => {
     };
     
     // Create minimal chunk model mock
-    mockChunkSqlModel = {
+    mockChunkModel = {
       addChunksBulk: vi.fn().mockImplementation(async (chunks) => {
         chunkStore.push(...chunks.map((chunk, i) => ({
           ...chunk,
@@ -84,7 +84,7 @@ describe('ChunkingService', () => {
     };
     
     // Create minimal embedding model mock
-    mockEmbeddingSqlModel = {
+    mockEmbeddingModel = {
       addEmbeddings: vi.fn().mockImplementation(async (embeddings) => {
         embeddingStore.push(...embeddings);
       }),
@@ -130,8 +130,8 @@ describe('ChunkingService', () => {
       10, // intervalMs
       mockAgent,
       mockObjectModel,
-      mockChunkSqlModel,
-      mockEmbeddingSqlModel,
+      mockChunkModel,
+      mockEmbeddingModel,
       mockIngestionJobModel
     );
   });
@@ -159,7 +159,7 @@ describe('ChunkingService', () => {
     expect(mockObjectModel.findByStatus).toHaveBeenCalledWith(['parsed']);
     expect(mockObjectModel.updateStatus).toHaveBeenCalledWith('test-1', 'embedding');
     expect(mockAgent.chunkText).toHaveBeenCalled();
-    expect(mockChunkSqlModel.addChunksBulk).toHaveBeenCalled();
+    expect(mockChunkModel.addChunksBulk).toHaveBeenCalled();
     expect(mockVectorStore.addDocuments).toHaveBeenCalled();
     
     // Check that chunks were created
@@ -207,7 +207,7 @@ describe('ChunkingService', () => {
     expect(mockAgent.chunkText).toHaveBeenCalled();
     
     // Should not have created chunks due to error
-    expect(mockChunkSqlModel.addChunksBulk).not.toHaveBeenCalled();
+    expect(mockChunkModel.addChunksBulk).not.toHaveBeenCalled();
   });
 
   it('runs in polling mode', async () => {
@@ -245,6 +245,6 @@ describe('ChunkingService', () => {
     // Should only check for objects
     expect(mockObjectModel.findByStatus).toHaveBeenCalledWith(['parsed']);
     expect(mockAgent.chunkText).not.toHaveBeenCalled();
-    expect(mockChunkSqlModel.addChunksBulk).not.toHaveBeenCalled();
+    expect(mockChunkModel.addChunksBulk).not.toHaveBeenCalled();
   });
 });

--- a/services/ingestion/_tests/UrlIngestionWorker.test.ts
+++ b/services/ingestion/_tests/UrlIngestionWorker.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect, beforeEach, afterEach, vi, Mock } from 'vitest';
 import Database from 'better-sqlite3';
 import { IngestionJobModel } from '../../../models/IngestionJobModel';
 import { ObjectModel } from '../../../models/ObjectModel';
-import { EmbeddingSqlModel } from '../../../models/EmbeddingModel';
-import { ChunkSqlModel } from '../../../models/ChunkModel';
+import { EmbeddingModel } from '../../../models/EmbeddingModel';
+import { ChunkModel } from '../../../models/ChunkModel';
 import { IngestionQueueService } from '../IngestionQueueService';
 import { ChunkingService } from '../ChunkingService';
 import type { IVectorStore, IngestionJob } from '../../../shared/types';
@@ -414,8 +414,8 @@ describe('URL Ingestion Pipeline - Integration', () => {
   let db: Database.Database;
   let objectModel: ObjectModel;
   let ingestionJobModel: IngestionJobModel;
-  let chunkModel: ChunkSqlModel;
-  let embeddingSqlModel: EmbeddingSqlModel;
+  let chunkModel: ChunkModel;
+  let embeddingModel: EmbeddingModel;
   let ingestionQueueService: IngestionQueueService;
   let chunkingService: ChunkingService;
   let urlWorker: UrlIngestionWorker;
@@ -429,8 +429,8 @@ describe('URL Ingestion Pipeline - Integration', () => {
     // Initialize models
     objectModel = new ObjectModel(db);
     ingestionJobModel = new IngestionJobModel(db);
-    chunkModel = new ChunkSqlModel(db);
-    embeddingSqlModel = new EmbeddingSqlModel(db);
+    chunkModel = new ChunkModel(db);
+    embeddingModel = new EmbeddingModel(db);
     
     // Mock vector store
     vectorStore = {
@@ -457,7 +457,7 @@ describe('URL Ingestion Pipeline - Integration', () => {
       undefined,
       objectModel,
       chunkModel,
-      embeddingSqlModel,
+      embeddingModel,
       ingestionJobModel,
       5
     );


### PR DESCRIPTION
Since all models use SQLite and there's no indication of future non-SQL implementations, the "Sql" suffix adds no value and creates inconsistency.

Changes:
- Rename ChunkSqlModel → ChunkModel
- Rename EmbeddingSqlModel → EmbeddingModel
- Update all imports, type references, and property names throughout codebase
- Update log messages and comments to use new names

This brings these models in line with other models like ObjectModel, ChatModel, and NotebookModel that don't have the redundant suffix.

🤖 Generated with [Claude Code](https://claude.ai/code)