### PR TITLE
fix: chat responses display issue, 'key' prop issue, and smooth scrolling while streaming

### DIFF
--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -139,6 +139,7 @@ import {
   WeatherData,
   AudioTranscribePayload,
   UpdateStatus,
+  StreamChunkEvent,
 } from '../shared/types';
 
 console.log('[Preload Script] Loading...');
@@ -241,7 +242,7 @@ const api = {
 
   // Listener for incoming chat chunks (Main -> Renderer)
   onChatChunk: (callback: (chunk: string) => void) => {
-    const listener = (_event: Electron.IpcRendererEvent, chunk: string) => callback(chunk);
+    const listener = (_event: Electron.IpcRendererEvent, chunkEvent: StreamChunkEvent) => callback(chunkEvent.chunk);
     ipcRenderer.on(ON_CHAT_RESPONSE_CHUNK, listener);
     return () => ipcRenderer.removeListener(ON_CHAT_RESPONSE_CHUNK, listener);
   },

--- a/src/components/apps/chat/ChatWindow.tsx
+++ b/src/components/apps/chat/ChatWindow.tsx
@@ -30,8 +30,8 @@ export const ChatWindow: React.FC<ChatWindowProps> = ({ payload, windowId, noteb
 
   // Mapping function for Chat component props, as suggested for minor refinement
   const mapMessagesForChat = (msgs: typeof messages) => {
-    return msgs.map(msg => ({
-      id: msg.messageId,
+    return msgs.map((msg, index) => ({
+      id: msg.messageId || `message-${index}`,
       role: msg.role,
       content: msg.content,
       // Example for custom UI based on metadata or other properties from StructuredChatMessage

--- a/src/hooks/use-auto-scroll.ts
+++ b/src/hooks/use-auto-scroll.ts
@@ -1,20 +1,39 @@
-import { useEffect, useRef, useState } from "react"
+import { useEffect, useRef, useState, useCallback } from "react"
 
 // How many pixels from the bottom of the container to enable auto-scroll
 const ACTIVATION_THRESHOLD = 50
 // Minimum pixels of scroll-up movement required to disable auto-scroll
 const MIN_SCROLL_UP_THRESHOLD = 10
+// Debounce delay for auto-scroll during rapid updates (e.g., streaming)
+const AUTO_SCROLL_DEBOUNCE_MS = 50
 
 export function useAutoScroll(dependencies: React.DependencyList) {
   const containerRef = useRef<HTMLDivElement | null>(null)
   const previousScrollTop = useRef<number | null>(null)
   const [shouldAutoScroll, setShouldAutoScroll] = useState(true)
+  const scrollTimeoutRef = useRef<NodeJS.Timeout | null>(null)
 
   const scrollToBottom = () => {
+    // Cancel any pending debounced scroll
+    if (scrollTimeoutRef.current) {
+      clearTimeout(scrollTimeoutRef.current)
+      scrollTimeoutRef.current = null
+    }
+    
     if (containerRef.current) {
       containerRef.current.scrollTop = containerRef.current.scrollHeight
     }
   }
+
+  const debouncedScrollToBottom = useCallback(() => {
+    if (scrollTimeoutRef.current) {
+      clearTimeout(scrollTimeoutRef.current)
+    }
+    
+    scrollTimeoutRef.current = setTimeout(() => {
+      scrollToBottom()
+    }, AUTO_SCROLL_DEBOUNCE_MS)
+  }, [])
 
   const handleScroll = () => {
     if (containerRef.current) {
@@ -58,10 +77,19 @@ export function useAutoScroll(dependencies: React.DependencyList) {
 
   useEffect(() => {
     if (shouldAutoScroll) {
-      scrollToBottom()
+      debouncedScrollToBottom()
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, dependencies)
+
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (scrollTimeoutRef.current) {
+        clearTimeout(scrollTimeoutRef.current)
+      }
+    }
+  }, [])
 
   return {
     containerRef,


### PR DESCRIPTION
This PR fixes three issues:
- The chat responses were getting displayed as "[Object][Object]" because preload was receiving chunk objects, not the chink strings.
- Fixes error: "Each child in a list should have a unique 'key' prop." that was occurring when chat responses were received.
- The chat div where the responses were streamed into would sort shake and shiver when the tokens were streaming. Added a small 50ms debounce so that it's smoother.

I just wanted to make chat usable with this PR and I believe I have done that. The only problem I still see is that when a second question is asked, the answer to it is streamed on top of (i.e before) the second question while streaming. It renders as it should after the streaming is over. I think we can get that one later.

https://github.com/user-attachments/assets/766c0069-cff8-4df7-bc58-82e3643a549e



