### PR TITLE
Fix window resize cursor visibility

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -130,3 +130,35 @@
 .notebook-dropdown {
   z-index: var(--dropdown-z-index, 10000) !important;
 }
+
+/* React-rnd/re-resizable resize handle cursor fixes */
+/* Target divs with specific cursor inline styles */
+div[style*="cursor: row-resize"] {
+  cursor: ns-resize !important;
+}
+
+div[style*="cursor: col-resize"] {
+  cursor: ew-resize !important;
+}
+
+div[style*="cursor: ne-resize"] {
+  cursor: nesw-resize !important;
+}
+
+div[style*="cursor: se-resize"] {
+  cursor: nwse-resize !important;
+}
+
+div[style*="cursor: sw-resize"] {
+  cursor: nesw-resize !important;
+}
+
+div[style*="cursor: nw-resize"] {
+  cursor: nwse-resize !important;
+}
+
+/* Ensure resize handles are interactive */
+.will-change-transform > div[style*="position: absolute"][style*="cursor"] {
+  pointer-events: auto !important;
+  z-index: 10 !important;
+}


### PR DESCRIPTION
## Summary
- Fixed unreliable cursor display when hovering over window resize handles
- Added CSS rules to properly show resize cursors for all directions

## Problem
The resize cursors on WindowFrame components weren't showing reliably when users hovered over the resize areas. This made it difficult to know when the window could be resized.

## Solution
The re-resizable library (used by react-rnd) applies cursor styles using inline styles. These weren't being displayed properly due to CSS specificity issues. 

Added targeted CSS rules that:
- Match resize handles by their inline cursor styles
- Override with proper cursor values for all resize directions (ns-resize, ew-resize, etc.)
- Ensure resize handles are interactive with appropriate z-index

## Test plan
- [ ] Open the application and create a window
- [ ] Hover over the edges and corners of the window
- [ ] Verify that the cursor changes to the appropriate resize cursor
- [ ] Test all resize directions: top, bottom, left, right, and all four corners
- [ ] Verify that windows can still be resized as expected

🤖 Generated with [Claude Code](https://claude.ai/code)