### PR TITLE
Freeze active browser on sidebar hover

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -44,6 +44,38 @@ interface AppSidebarProps {
 
 export function AppSidebar({ onAddChat, onAddBrowser, onGoHome, windows = [], activeStore, notebookId }: AppSidebarProps) {
   const minimizedWindows = windows.filter(w => w.isMinimized);
+
+  const handleSidebarMouseEnter = () => {
+    if (!activeStore) return;
+
+    const { windows, updateWindowProps } = activeStore.getState();
+    const activeWindow = windows.find(w => w.isFocused);
+
+    if (activeWindow && activeWindow.type === 'classic-browser') {
+      const payload = activeWindow.payload as ClassicBrowserPayload;
+      if (payload.freezeState.type === 'ACTIVE') {
+        updateWindowProps(activeWindow.id, {
+          payload: { ...payload, freezeState: { type: 'CAPTURING' } }
+        });
+      }
+    }
+  };
+
+  const handleSidebarMouseLeave = () => {
+    if (!activeStore) return;
+
+    const { windows, updateWindowProps } = activeStore.getState();
+    const activeWindow = windows.find(w => w.isFocused);
+
+    if (activeWindow && activeWindow.type === 'classic-browser') {
+      const payload = activeWindow.payload as ClassicBrowserPayload;
+      if (payload.freezeState.type !== 'ACTIVE') {
+        updateWindowProps(activeWindow.id, {
+          payload: { ...payload, freezeState: { type: 'ACTIVE' } }
+        });
+      }
+    }
+  };
   
   const handleNewNote = () => {
     if (!activeStore || !notebookId) return;
@@ -65,7 +97,14 @@ export function AppSidebar({ onAddChat, onAddBrowser, onGoHome, windows = [], ac
   
   
   return (
-    <Sidebar side="right" variant="floating" className="bg-step-1 border-step-6 p-1" collapsible="icon">
+    <Sidebar
+      side="right"
+      variant="floating"
+      className="bg-step-1 border-step-6 p-1"
+      collapsible="icon"
+      onMouseEnter={handleSidebarMouseEnter}
+      onMouseLeave={handleSidebarMouseLeave}
+    >
       <SidebarRail />
       <SidebarHeader className="py-4 px-1">
         <SidebarMenu>


### PR DESCRIPTION
## Summary
- freeze the focused ClassicBrowser window when hovering the sidebar
- unfreeze when the pointer leaves the sidebar

## Testing
- `npm test` *(fails: `vitest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687ee6db25448323ace1a7da6e2caea8