### PR TITLE
Freeze active browser on sidebar hover

### DIFF
--- a/src/components/NotebookView.tsx
+++ b/src/components/NotebookView.tsx
@@ -50,7 +50,7 @@ function NotebookContent({
   isIntentLineVisible: boolean;
   setIsIntentLineVisible: (visible: boolean) => void;
 }) {
-  const { state: sidebarState } = useSidebar();
+  const { state: sidebarState, isHovered } = useSidebar();
   const [isPillHovered, setIsPillHovered] = useState(false);
   const [isPillClicked, setIsPillClicked] = useState(false);
   const intentLineRef = useRef<HTMLInputElement>(null);
@@ -103,6 +103,27 @@ function NotebookContent({
       // Could show an error toast here
     }
   };
+
+  // Freeze active browser when sidebar is hovered
+  useEffect(() => {
+    const focused = activeStore.getState().windows.find(w => w.isFocused);
+    if (!focused || focused.type !== 'classic-browser') return;
+    const payload = focused.payload as ClassicBrowserPayload;
+
+    if (isHovered) {
+      if (payload.freezeState.type === 'ACTIVE') {
+        activeStore.getState().updateWindowProps(focused.id, {
+          payload: { ...payload, freezeState: { type: 'CAPTURING' } } as ClassicBrowserPayload
+        });
+      }
+    } else {
+      if (payload.freezeState.type !== 'ACTIVE') {
+        activeStore.getState().updateWindowProps(focused.id, {
+          payload: { ...payload, freezeState: { type: 'ACTIVE' } } as ClassicBrowserPayload
+        });
+      }
+    }
+  }, [isHovered, activeStore]);
   
   return (
     <>

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -39,6 +39,8 @@ type SidebarContextProps = {
   setOpenMobile: (open: boolean) => void
   isMobile: boolean
   toggleSidebar: () => void
+  isHovered: boolean
+  setIsHovered: (hovered: boolean) => void
 }
 
 const SidebarContext = React.createContext<SidebarContextProps | null>(null)
@@ -67,6 +69,7 @@ function SidebarProvider({
 }) {
   const isMobile = useIsMobile()
   const [openMobile, setOpenMobile] = React.useState(false)
+  const [isHovered, setIsHovered] = React.useState(false)
 
   // This is the internal state of the sidebar.
   // We use openProp and setOpenProp for control from outside the component.
@@ -107,8 +110,10 @@ function SidebarProvider({
       openMobile,
       setOpenMobile,
       toggleSidebar,
+      isHovered,
+      setIsHovered,
     }),
-    [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar]
+    [state, open, setOpen, isMobile, openMobile, setOpenMobile, toggleSidebar, isHovered]
   )
 
   return (
@@ -148,7 +153,7 @@ function Sidebar({
   variant?: "sidebar" | "floating" | "inset"
   collapsible?: "offcanvas" | "icon" | "none"
 }) {
-  const { isMobile, state, openMobile, setOpenMobile } = useSidebar()
+  const { isMobile, state, openMobile, setOpenMobile, setIsHovered } = useSidebar()
 
   if (collapsible === "none") {
     return (
@@ -198,6 +203,8 @@ function Sidebar({
       data-variant={variant}
       data-side={side}
       data-slot="sidebar"
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
     >
       {/* This is what handles the sidebar gap on desktop */}
       <div


### PR DESCRIPTION
## Summary
- add sidebar hover tracking
- freeze/unfreeze active browser when hovering the sidebar

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: vitest not found)*
- `npm run typecheck` *(fails: cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_687ee6db25448323ace1a7da6e2caea8