### PR TITLE
Auto-freeze browser windows when sidebar expands

### DIFF
--- a/src/components/ui/hover-card.tsx
+++ b/src/components/ui/hover-card.tsx
@@ -32,7 +32,7 @@ function HoverCardContent({
         align={align}
         sideOffset={sideOffset}
         className={cn(
-          "bg-popover data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-64 origin-(--radix-hover-card-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
+          "bg-popover data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-[1100] w-64 origin-(--radix-hover-card-content-transform-origin) rounded-md border p-4 shadow-md outline-hidden",
           className
         )}
         {...props}

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -214,7 +214,7 @@ function Sidebar({
       <div
         data-slot="sidebar-container"
         className={cn(
-          "fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
+          "fixed inset-y-0 z-[1000] hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear md:flex",
           side === "left"
             ? "left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]"
             : "right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]",
@@ -276,7 +276,7 @@ function SidebarRail({ className, ...props }: React.ComponentProps<"button">) {
       onClick={toggleSidebar}
       title="Toggle Sidebar"
       className={cn(
-        "absolute inset-y-0 z-30 hidden w-2 transition-all ease-linear sm:flex",
+        "absolute inset-y-0 z-[1000] hidden w-2 transition-all ease-linear sm:flex",
         "bg-transparent hover:bg-step-4",
         // For right-sided sidebar, the rail is on the left edge
         "[[data-side=right]_&]:left-0",

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -46,13 +46,13 @@ function TooltipContent({
         data-slot="tooltip-content"
         sideOffset={sideOffset}
         className={cn(
-          "bg-step-11 text-step-1 animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+          "bg-step-11 text-step-1 animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-[1100] w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
           className
         )}
         {...props}
       >
         {children}
-        <TooltipPrimitive.Arrow className="bg-step-11 fill-step-11 z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+        <TooltipPrimitive.Arrow className="bg-step-11 fill-step-11 z-[1100] size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
       </TooltipPrimitive.Content>
     </TooltipPrimitive.Portal>
   )


### PR DESCRIPTION
## Summary
- Implements automatic freezing/unfreezing of ClassicBrowser windows based on sidebar state
- Prevents z-index conflicts and reduces resource usage when sidebar overlays browser content
- Updates component z-indexes to ensure proper layering (sidebar: z-[1000], hover elements: z-[1100])

## Implementation Details

### Browser Window Freezing
- Added `useEffect` in `NotebookContent` component to monitor sidebar state changes
- When sidebar expands: Freezes the active browser window by setting `freezeState` to 'CAPTURING'
- When sidebar collapses: Unfreezes by setting `freezeState` back to 'ACTIVE'
- Only affects the currently focused ClassicBrowser window (not minimized windows or other content types)

### Z-Index Updates
- Sidebar container and rail: `z-[1000]` (previously z-10 and z-30)
- HoverCard content: `z-[1100]` (previously z-50)
- Tooltip content and arrow: `z-[1100]` (previously z-50)

This ensures hover elements (minimized window previews, tooltips) appear above the sidebar.

### Architecture
The implementation leverages the existing freeze/unfreeze state machine without modification:
1. Setting `freezeState` to 'CAPTURING' triggers the existing capture flow
2. The `useBrowserWindowController` hook handles snapshot capture and view hiding
3. Setting back to 'ACTIVE' reveals the WebContentsView

## Test Plan
- [x] Expand sidebar and verify active browser window freezes
- [x] Collapse sidebar and verify browser window unfreezes
- [x] Test with multiple windows - only active window should freeze
- [x] Verify hover cards and tooltips appear above sidebar
- [x] Test with non-browser windows (chat, notes) - should not be affected

🤖 Generated with [Claude Code](https://claude.ai/code)